### PR TITLE
Added support for Jet

### DIFF
--- a/modulefiles/gdas2gldas.jet
+++ b/modulefiles/gdas2gldas.jet
@@ -1,0 +1,20 @@
+#%Module#####################################################
+## Build module for Jet
+#############################################################
+
+module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/18.0.5.274
+module load hpc-impi/2018.4.274
+
+module load w3nco/2.4.1
+module load nemsio/2.5.2
+module load bacio/2.4.1
+module load sp/2.3.3 
+ 
+module load netcdf/4.7.4
+module load hdf5/1.10.6
+module load esmf/8_1_1
+
+export FCOMP=mpiifort
+export FFLAGS="-O3 -fp-model precise -g -traceback -r8 -i4 -qopenmp -convert big_endian -assume byterecl"

--- a/modulefiles/gldas2gdas.jet
+++ b/modulefiles/gldas2gdas.jet
@@ -1,0 +1,20 @@
+#%Module#####################################################
+## Build module for Jet
+#############################################################
+
+module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/18.0.5.274
+module load hpc-impi/2018.4.274
+
+module load w3nco/2.4.1
+module load nemsio/2.5.2
+module load bacio/2.4.1
+module load sp/2.3.3 
+ 
+module load netcdf/4.7.4
+module load hdf5/1.10.6
+module load esmf/8_1_1
+
+export FCOMP=mpiifort
+export FFLAGS="-O3 -fp-model precise -g -traceback -r8 -i4 -qopenmp -convert big_endian -assume byterecl"

--- a/modulefiles/gldas_forcing.jet
+++ b/modulefiles/gldas_forcing.jet
@@ -1,0 +1,13 @@
+#%Module#####################################################
+## Build module for Jet
+#############################################################
+
+module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/18.0.5.274
+
+module load w3nco/2.4.1
+module load bacio/2.4.1
+
+export FC=ifort
+export FOPTS="-O0 -FR"

--- a/modulefiles/gldas_model.jet
+++ b/modulefiles/gldas_model.jet
@@ -1,0 +1,14 @@
+#%Module#####################################################
+## Build module for Jet
+#############################################################
+
+module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/18.0.5.274
+module load hpc-impi/2018.4.274
+
+module load w3emc/2.7.3
+module load w3nco/2.4.1
+module load bacio/2.4.1
+module load sp/2.3.3
+module load ip/3.3.3

--- a/modulefiles/gldas_post.jet
+++ b/modulefiles/gldas_post.jet
@@ -1,0 +1,16 @@
+#%Module#####################################################
+## Build module for Jet
+#############################################################
+
+module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/18.0.5.274
+module load hpc-impi/2018.4.274
+
+module load w3nco/2.4.1
+module load w3emc/2.7.3
+module load bacio/2.4.1
+module load nemsio/2.5.2
+
+export FC=ifort
+export FOPTS='-O -FR -I$(NEMSIO_INC) -convert big_endian'

--- a/modulefiles/gldas_rst.jet
+++ b/modulefiles/gldas_rst.jet
@@ -1,0 +1,16 @@
+#%Module#####################################################
+## Build module for Jet
+#############################################################
+
+module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/18.0.5.274
+module load hpc-impi/2018.4.274
+
+module load w3nco/2.4.1
+module load w3emc/2.7.3
+module load bacio/2.4.1
+module load nemsio/2.5.2
+
+export FC=ifort
+export FOPTS='-O -FR -I$(NEMSIO_INC) -convert big_endian'


### PR DESCRIPTION
The build scripts have been ported to Jet to support the global workflow.  This has been tested on both xjet and kjet.

A test case at C192/C96 has finished running through 2020080500.  The data from the run can be found as follows
Logs: /lfs1/NESDIS/nesdis-rdo2/David.Huber/para/com/test_192b/logs/2020080500/gdasgldas.log
Rotdir: /lfs1/NESDIS/nesdis-rdo2/David.Huber/para/com/test_192b
Archive: /lfs1/NESDIS/nesdis-rdo2/David.Huber/archive/test_192b

Fixes #25